### PR TITLE
Make namenode  rpc and resourcemanager webapp port numbers configurable.

### DIFF
--- a/jes/index_cluster_stats.py
+++ b/jes/index_cluster_stats.py
@@ -14,7 +14,7 @@ log = get_logger('inviso.cluster')
 es_index = 'inviso-cluster'
 
 def index_apps(es, cluster, info):
-    apps = requests.get('http://%s:%s/ws/v1/cluster/apps?state=RUNNING' % (cluster.host, '9026'), headers = {'ACCEPT':'application/json'}).json().get('apps')
+    apps = requests.get('http://%s:%s/ws/v1/cluster/apps?state=RUNNING' % (cluster.host, cluster.resourcemanager_webapp_port), headers = {'ACCEPT':'application/json'}).json().get('apps')
     
     if not apps:
         log.info(cluster.name + ': no applications running.')
@@ -51,7 +51,7 @@ def index_apps(es, cluster, info):
     log.debug(bulk(es, documents, stats_only=True));
 
 def index_metrics(es, cluster, info):
-    metrics = requests.get('http://%s:%s/ws/v1/cluster/metrics' % (cluster.host, '9026'), headers = {'ACCEPT':'application/json'}).json()['clusterMetrics']
+    metrics = requests.get('http://%s:%s/ws/v1/cluster/metrics' % (cluster.host, cluster.resourcemanager_webapp_port), headers = {'ACCEPT':'application/json'}).json()['clusterMetrics']
     metrics.update(info)
     
     r = es.index(index=es_index, 
@@ -63,7 +63,7 @@ def index_metrics(es, cluster, info):
     log.debug(r)
 
 def index_scheduler(es, cluster, info):
-    scheduler = requests.get('http://%s:%s/ws/v1/cluster/scheduler' % (cluster.host, '9026'), headers = {'ACCEPT':'application/json'}).json()['scheduler']['schedulerInfo']['rootQueue']
+    scheduler = requests.get('http://%s:%s/ws/v1/cluster/scheduler' % (cluster.host, cluster.resourcemanager_webapp_port), headers = {'ACCEPT':'application/json'}).json()['scheduler']['schedulerInfo']['rootQueue']
     scheduler.update(info)
 
     r = es.index(index=es_index, 

--- a/jes/inviso/monitor.py
+++ b/jes/inviso/monitor.py
@@ -17,10 +17,12 @@ EPOCH = datetime(1970, 1, 1, tzinfo=pytz.UTC)
 
 
 class Cluster:
-    def __init__(self, id, name, host):
+    def __init__(self, id, name, host, namenode_rpc_port, resourcemanager_webapp_port):
         self.id = id
         self.name = name
         self.host = host
+        self.namenode_rpc_port = namenode_rpc_port
+        self.resourcemanager_webapp_port = resourcemanager_webapp_port
 
 class Monitor(object):
     def __init__(self, publisher=None, chunk_size=10, **kwargs):

--- a/jes/jes.py
+++ b/jes/jes.py
@@ -27,6 +27,7 @@ def main():
                                           cluster_id=cluster.id, 
                                           cluster_name=cluster.name, 
                                           host=cluster.host,
+                                          port=cluster.namenode_rpc_port,
                                           publisher=publisher,
                                           elasticsearch=settings.elasticsearch))
     

--- a/jes/settings_default.py
+++ b/jes/settings_default.py
@@ -65,7 +65,13 @@ genie_host = 'localhost:8080'
 elasticsearch_hosts = [{'host': 'localhost', 'port': 9200}]
 elasticsearch = Elasticsearch(elasticsearch_hosts)
 clusters = [
-    Cluster(id='cluster_1', name='cluster_1', host=socket.getfqdn())
+    Cluster(
+      id='cluster_1',
+      name='cluster_1',
+      host=socket.getfqdn(),
+      namenode_rpc_port = 9000,
+      resourcemanager_webapp_port = 9026
+    )
 ]
 
 handler = IndexHandler(trace=inviso_trace, elasticsearch=elasticsearch)

--- a/jes/settings_default.py
+++ b/jes/settings_default.py
@@ -69,8 +69,8 @@ clusters = [
       id='cluster_1',
       name='cluster_1',
       host=socket.getfqdn(),
-      namenode_rpc_port = 9000,
-      resourcemanager_webapp_port = 9026
+      namenode_rpc_port = 8020,
+      resourcemanager_webapp_port = 8088
     )
 ]
 


### PR DESCRIPTION
The namenode RPC port (dfs.namenode.rpc-address....) is currently hardcoded to 9000, and the resourcemanager webapp port (yarn.resourcemanager.webapp.address...) hardcoded to 9032, which isn't typical, and requires users to update the port numbers in the Python scripts.

This update allows the ports to be defined in settings.py.